### PR TITLE
handle empty string correctly & allow disabling keybindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ use {
   'abecodes/tabout.nvim',
   config = function()
     require('tabout').setup {
-    tabkey = '<Tab>', -- key to trigger tabout
-    backwards_tabkey = '<S-Tab>', -- key to trigger backwards tabout
+    tabkey = '<Tab>', -- key to trigger tabout, set to an empty string to disable
+    backwards_tabkey = '<S-Tab>', -- key to trigger backwards tabout, set to an empty string to disable
     act_as_tab = true, -- shift content if tab out is not possible
     act_as_shift_tab = false, -- reverse shift content if tab out is not possible (if your keyboard/terminal supports <S-Tab>)
     enable_backwards = true, -- well ...
@@ -147,6 +147,46 @@ property, etc.
 ```lua
 -- default
 ignore_beginning = true
+```
+
+### more complex keybindings
+
+You can set `tabkey` and `backwards_tabkey` to empty strings and define more complex keybindings instead.
+
+For example, to make `<Tab>` and `<S-Tab>` work with [nvim-compe](https://github.com/hrsh7th/nvim-compe), [vim-vsnip](https://github.com/hrsh7th/vim-vsnip) and this plugin:
+
+```lua
+require("tabout").setup({
+  tabkey = "",
+  backwards_tabkey = "",
+})
+
+local function replace_keycodes(str)
+  return vim.api.nvim_replace_termcodes(str, true, true, true)
+end
+
+function _G.tab_binding()
+  if vim.fn.pumvisible() ~= 0 then
+    return replace_keycodes("<C-n>")
+  elseif vim.fn["vsnip#available"](1) ~= 0 then
+    return replace_keycodes("<Plug>(vsnip-expand-or-jump)")
+  else
+    return replace_keycodes("<Cmd>Tabout<CR>")
+  end
+end
+
+function _G.s_tab_binding()
+  if vim.fn.pumvisible() ~= 0 then
+    return replace_keycodes("<C-p>")
+  elseif vim.fn["vsnip#jumpable"](-1) ~= 0 then
+    return replace_keycodes("<Plug>(vsnip-jump-prev)")
+  else
+    return replace_keycodes("<Cmd>TaboutBack<CR>")
+  end
+end
+
+vim.api.nvim_set_keymap("i", "<Tab>", "v:lua.tab_binding()", {expr = true})
+vim.api.nvim_set_keymap("i", "<S-Tab>", "v:lua.s_tab_binding()", {expr = true})
 ```
 
 <p>&nbsp;</p>

--- a/lua/tabout.lua
+++ b/lua/tabout.lua
@@ -12,25 +12,25 @@ local completion_binding = ''
 local completion_binding_back = ''
 
 local enable = function()
-    completion_binding = vim.fn.maparg(config.options.tabkey, 'i')
-    completion_binding_back = vim.fn
-                                  .maparg(config.options.backwards_tabkey, 'i')
-
-    if config.options.completion and completion_binding then
-        if config.debug then
-            logger.log('setting: ' .. config.options.tabkey ..
-                           ':!pumvisible() ? "<Cmd>Tabout<Cr>" : ' ..
-                           completion_binding)
+    if config.options.tabkey ~= '' then
+        completion_binding = vim.fn.maparg(config.options.tabkey, 'i')
+        if config.options.completion and completion_binding ~= '' then
+            if config.debug then
+                logger.log('setting: ' .. config.options.tabkey ..
+                               ':!pumvisible() ? "<Cmd>Tabout<Cr>" : ' ..
+                               completion_binding)
+            end
+            utils.map('i', config.options.tabkey,
+                      '!pumvisible() ? "<Cmd>Tabout<Cr>" : ' .. completion_binding,
+                      {silent = true, expr = true})
+        else
+            utils.map('i', config.options.tabkey, "<Cmd>Tabout<Cr>", {silent = true})
         end
-        utils.map('i', config.options.tabkey,
-                  '!pumvisible() ? "<Cmd>Tabout<Cr>" : ' .. completion_binding,
-                  {silent = true, expr = true})
-    else
-        utils.map('i', config.options.tabkey, "<Cmd>Tabout<Cr>", {silent = true})
     end
 
-    if config.options.enable_backwards then
-        if config.options.completion and completion_binding_back then
+    if config.options.backwards_tabkey ~= '' and config.options.enable_backwards then
+        completion_binding_back = vim.fn.maparg(config.options.backwards_tabkey, 'i')
+        if config.options.completion and completion_binding_back ~= '' then
             if config.debug then
                 logger.log('setting: ' .. config.options.backwards_tabkey ..
                                ':!pumvisible() ? "<Cmd>TaboutBack<Cr>" : ' ..
@@ -51,27 +51,27 @@ end
 
 local disable = function()
     if config.debug then logger.log("unsetting: " .. config.options.tabkey) end
-    utils.unmap('i', config.options.tabkey)
 
-    if config.options.enable_backwards then
+    if config.options.tabkey ~= '' then
+        utils.unmap('i', config.options.tabkey)
+        if config.options.completion and completion_binding ~= '' then
+            if config.debug then
+                logger.log("resetting: " .. config.options.tabkey .. ": " ..
+                               completion_binding)
+            end
+            utils.map('i', config.options.tabkey, completion_binding, {
+                silent = true,
+                expr = string.sub(completion_binding, 1, 2) == 'v:'
+            })
+        end
+    end
+
+    if config.options.backwards_tabkey ~= '' and config.options.enable_backwards then
         if config.debug then
             logger.log("unsetting: " .. config.options.backwards_tabkey)
         end
         utils.unmap('i', config.options.backwards_tabkey)
-    end
-
-    if config.options.completion and completion_binding then
-        if config.debug then
-            logger.log("resetting: " .. config.options.tabkey .. ": " ..
-                           completion_binding)
-        end
-        utils.map('i', config.options.tabkey, completion_binding, {
-            silent = true,
-            expr = string.sub(completion_binding, 1, 2) == 'v:'
-        })
-    end
-    if config.options.enable_backwards then
-        if config.options.completion and completion_binding_back then
+        if config.options.completion and completion_binding_back ~= '' then
             if config.debug then
                 logger.log("resetting: " .. config.options.backwards_tabkey ..
                                ": " .. completion_binding_back)


### PR DESCRIPTION
Even empty strings evaluate to `true` in Lua, so `~= ''` should be used instead.

Sometimes one may want to prevent the plugin from defining keybindings and define the keybindings themselves instead. Setting a keybinding to an empty string will disable it.