### PR TITLE
stop ins-completion before moving cursor

### DIFF
--- a/lua/tabout/tab.lua
+++ b/lua/tabout/tab.lua
@@ -110,6 +110,10 @@ M.tabout = function(dir, enabled, multi)
         return tab_action()
     end
 
+    if api.nvim_get_mode().mode == 'ic' then
+      -- stop ins-completion without side-effects
+      api.nvim_feedkeys(utils.replace('<C-G><C-G>'), 'ni', true)
+    end
     return api.nvim_win_set_cursor(0, {line + 1, col})
 end
 


### PR DESCRIPTION
If ins-completion is active before moving cursor, Neovim treats the text
between the old and new cursor position as the text inserted by
completion, and will remove it if CTRL-E is pressed.

Why `<C-G><C-G>` is used: <https://github.com/vim/vim/issues/8784#issuecomment-906679787>.