### PR TITLE
replace deprecated `ts_utils.get_node_text()` to `vim.treesitter.query.get_node_text()`

### DIFF
--- a/lua/tabout/node.lua
+++ b/lua/tabout/node.lua
@@ -88,7 +88,7 @@ M.get_tabout_position = function(node, dir, multi)
     end
 
     if dir == 'backward' then
-        local text = ts_utils.get_node_text(node)
+        local text = vim.split(vim.treesitter.query.get_node_text(node, 0), '\n')
         logger.debug(text[1] .. ', ' .. tostring(node:end_()) .. ', ' ..
                          tostring(node:end_()) .. ', ' .. node:type() .. ', ' ..
                          text[#text])
@@ -112,7 +112,7 @@ end
 ---@return boolean
 ---@param node Node
 M.is_wrapped = function(node)
-    local text = ts_utils.get_node_text(node)
+    local text = vim.split(vim.treesitter.query.get_node_text(node, 0), '\n')
     if type(next(text)) ~= 'nil' then
         local first = string.sub(text[1], 1, 1)
         local last = string.sub(text[#text], -1)

--- a/lua/tabout/tab.lua
+++ b/lua/tabout/tab.lua
@@ -9,13 +9,13 @@ local M = {}
 
 local debug_node = function(line, col, node)
     if not node then logger.warn("No node at " .. line .. ":" .. col) end
-    local text = ts_utils.get_node_text(node)
+    local text = vim.split(vim.treesitter.query.get_node_text(node, 0), '\n')
     logger.warn(text[1] .. ', ' .. tostring(line) .. ', ' .. tostring(col) ..
                     ', ' .. node:type() .. ', ' .. text[#text])
 
     local parent = node:parent()
     if parent then
-        local text = ts_utils.get_node_text(parent)
+        local text = vim.split(vim.treesitter.query.get_node_text(parent, 0), '\n')
         logger.warn(
             text[1] .. ', ' .. tostring(line) .. ', ' .. tostring(col) .. ', ' ..
                 parent:type() .. ', ' .. text[#text])


### PR DESCRIPTION
due to https://github.com/nvim-treesitter/nvim-treesitter/pull/2801