### PR TITLE
docs(readme): changed completion engine plugin example

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ use {
 }
   end,
 	wants = {'nvim-treesitter'}, -- or require if not used so far
-	after = {'completion-nvim'} -- if a completion plugin is using tabs load it before
+	after = {'nvim-cmp'} -- if a completion plugin is using tabs load it before
 }
 ```
 


### PR DESCRIPTION
[https://github.com/nvim-lua/completion-nvim](completion-nvim) has become deprecated. changed it to [https://github.com/hrsh7th/nvim-cmp](nvim-cmp).