### PR TITLE
Switch from deprecated vim.treesitter.query.get_node_text()

### DIFF
--- a/lua/tabout/node.lua
+++ b/lua/tabout/node.lua
@@ -92,7 +92,7 @@ M.get_tabout_position = function(node, dir, multi)
     end
 
     -- if dir == 'backward' then
-    --     local text = vim.treesitter.query.get_node_text(node)
+    --     local text = vim.treesitter.get_node_text(node)
     --     logger.debug(text[1] .. ', ' .. tostring(node:end_()) .. ', ' ..
     --                      tostring(node:end_()) .. ', ' .. node:type() .. ', ' ..
     --                      text[#text])
@@ -121,7 +121,7 @@ end
 ---@return boolean
 ---@param node Node
 M.is_wrapped = function(node)
-    local text = vim.split(vim.treesitter.query.get_node_text(node, 0), '\n')
+    local text = vim.split(vim.treesitter.get_node_text(node, 0), '\n')
     if type(next(text)) ~= 'nil' then
         local first = string.sub(text[1], 1, 1)
         local last = string.sub(text[#text], -1)
@@ -164,7 +164,7 @@ M.scan_text = function(node, dir)
         parent = parent:parent()
     end
     logger.debug('scanning text inside ' .. parent:type() .. ' node')
-    text = vim.treesitter.query.get_node_text(parent, 0)
+    text = vim.treesitter.get_node_text(parent, 0)
 
     if (utils.str_is_empty(text)) then
         return nil, nil

--- a/lua/tabout/tab.lua
+++ b/lua/tabout/tab.lua
@@ -8,13 +8,13 @@ local M = {}
 
 local debug_node = function(line, col, node)
     if not node then logger.warn("No node at " .. line .. ":" .. col) end
-    local text = vim.split(vim.treesitter.query.get_node_text(node, 0), '\n')
+    local text = vim.split(vim.treesitter.get_node_text(node, 0), '\n')
     logger.warn(text[1] .. ', ' .. tostring(line) .. ', ' .. tostring(col) ..
                     ', ' .. node:type() .. ', ' .. text[#text])
 
     local parent = node:parent()
     if parent then
-        local text = vim.split(vim.treesitter.query.get_node_text(parent, 0), '\n')
+        local text = vim.split(vim.treesitter.get_node_text(parent, 0), '\n')
         logger.warn(
             text[1] .. ', ' .. tostring(line) .. ', ' .. tostring(col) .. ', ' ..
                 parent:type() .. ', ' .. text[#text])


### PR DESCRIPTION
Hello! 

This pull request resolves the following warning received when using tabout:

"vim.treesitter.query.get_node_text() is deprecated, use vim.treesitter.get_node_text() instead. :help deprecated
This feature will be removed in Nvim version 0.10"

Here's the relevant commit:
https://github.com/neovim/neovim/commit/cbbf8bd666c8419fdab80a0887948c8a36279c19

I hope this little contribution is helpful. I really enjoy your plugin : )
