### PR TITLE
handle no parser error

### DIFF
--- a/lua/tabout/node.lua
+++ b/lua/tabout/node.lua
@@ -45,7 +45,7 @@ M.get_node_at_cursor = function(dir)
       parser:parse()
     else
         if skip_notify[filetype] == nil then
-            vim.notify("tabout.vnim: No parser found for filetype " .. filetype)
+            vim.notify("tabout.nvim: No parser found for filetype " .. filetype)
             skip_notify[filetype] = true
         end
         return

--- a/lua/tabout/node.lua
+++ b/lua/tabout/node.lua
@@ -37,8 +37,8 @@ M.get_node_at_cursor = function(dir)
     local line = cursor[1] - 1
     local col = dir == 'backward' and cursor[2] and cursor[2] - 1 or cursor[2]
     local cursor_range = {line, col, line, col}
-    local parser = vim.treesitter.get_parser(0)
-    if parser then
+    local ok, parser = pcall(vim.treesitter.get_parser, 0)
+    if ok and parser then
       parser:parse()
     else
         logger.debug("get_node_at_cursor: No parser found for filetype " .. vim.bo[0].filetype)

--- a/lua/tabout/node.lua
+++ b/lua/tabout/node.lua
@@ -29,6 +29,8 @@ local get_parent_node = function(node, multi)
     end
 end
 
+local skip_notify = {}
+
 ---returns line,col or nil,nil
 ---@param dir string | "'forward'" | "'backward'"
 ---@return TSNode?
@@ -37,11 +39,15 @@ M.get_node_at_cursor = function(dir)
     local line = cursor[1] - 1
     local col = dir == 'backward' and cursor[2] and cursor[2] - 1 or cursor[2]
     local cursor_range = {line, col, line, col}
+    local filetype = vim.bo[0].filetype
     local ok, parser = pcall(vim.treesitter.get_parser, 0)
     if ok and parser then
       parser:parse()
     else
-        logger.debug("get_node_at_cursor: No parser found for filetype " .. vim.bo[0].filetype)
+        if skip_notify[filetype] == nil then
+            vim.notify("tabout.vnim: No parser found for filetype " .. filetype)
+            skip_notify[filetype] = true
+        end
         return
     end
     local tree = parser:tree_for_range(cursor_range)


### PR DESCRIPTION
It prints disturbing vim error message when there's no parser.
I don't know if there's other proper api to check if parser is available on buffer, but this workaround seems to work.

```
|| E5108: Error executing lua ...5c633/share/nvim/runtime/lua/vim/treesitter/language.lua:107: no parser for 'text' language, see :help treesitter-parsers
|| stack traceback:
|| 	[C]: in function 'error'
|| 	...5c633/share/nvim/runtime/lua/vim/treesitter/language.lua:107: in function 'add'
|| 	...3/share/nvim/runtime/lua/vim/treesitter/languagetree.lua:111: in function 'new'
|| 	...rapped-4e5c633/share/nvim/runtime/lua/vim/treesitter.lua:41: in function '_create_parser'
|| 	...rapped-4e5c633/share/nvim/runtime/lua/vim/treesitter.lua:108: in function 'get_parser'
|| 	...vim/site/pack/bundle/opt/tabout.nvim/lua/tabout/node.lua:40: in function 'get_node_at_cursor'
|| 	...nvim/site/pack/bundle/opt/tabout.nvim/lua/tabout/tab.lua:86: in function 'tabout'
|| 	...are/nvim/site/pack/bundle/opt/tabout.nvim/lua/tabout.lua:139: in function 'tabout'
|| 	[string ":lua"]:1: in main chunk
```